### PR TITLE
Adds public accessors for init & variables we need to use

### DIFF
--- a/Sources/NextLevel+Hush.swift
+++ b/Sources/NextLevel+Hush.swift
@@ -1,0 +1,20 @@
+//
+//  NextLevel+Hush.swift
+//  NextLevel
+//
+//  Created by Brophy on 7/23/18.
+//
+
+import Foundation
+import AVFoundation
+
+/// Extension on NextLevelSession to publicly expose some variables that we need.
+public extension NextLevelSession {
+    public var videoInput: AVAssetWriterInput? {
+        return self._videoInput
+    }
+    
+    public var audioInput: AVAssetWriterInput? {
+        return self._audioInput
+    }
+}

--- a/Sources/NextLevelConfiguration.swift
+++ b/Sources/NextLevelConfiguration.swift
@@ -141,7 +141,7 @@ public class NextLevelVideoConfiguration: NextLevelConfiguration {
         
     // MARK: - object lifecycle
     
-    override init() {
+    override public init() {
         if #available(iOS 11.0, *) {
             self.codec = AVVideoCodecType.h264.rawValue
         } else {
@@ -277,7 +277,7 @@ public class NextLevelAudioConfiguration: NextLevelConfiguration {
 
     // MARK: - object lifecycle
     
-    override init() {
+    override public init() {
         super.init()
     }
 

--- a/Sources/NextLevelSession.swift
+++ b/Sources/NextLevelSession.swift
@@ -195,7 +195,7 @@ public class NextLevelSession {
     /// - Parameters:
     ///   - queue: Queue for a session operations
     ///   - queueKey: Key for re-calling the session queue from the system
-    convenience init(queue: DispatchQueue, queueKey: DispatchSpecificKey<()>) {
+    convenience public init(queue: DispatchQueue, queueKey: DispatchSpecificKey<()>) {
         self.init()
         self._sessionQueue = queue
         self._sessionQueueKey = queueKey


### PR DESCRIPTION
Summary:

- Makes the Video & Audio Configuration objects have public initializers
- Adds public accessors to the video and audio input on the NextLevelSession via an extension

Reviewers:
jtumarki
Brophy

Test Plan:
fairly basic, didn't really test

Revert Plan:
git revert